### PR TITLE
Fix for pre-ios7

### DIFF
--- a/BufferedNavigationController.m
+++ b/BufferedNavigationController.m
@@ -123,14 +123,17 @@
 
     @synchronized (self.stack) {
         self.transitioning = true;
-        id <UIViewControllerTransitionCoordinator> transitionCoordinator = navigationController.topViewController.transitionCoordinator;
-        [transitionCoordinator notifyWhenInteractionEndsUsingBlock:^(id <UIViewControllerTransitionCoordinatorContext> context) {
-            if ([context isCancelled]) {
-                @synchronized (self.stack) {
-                    self.transitioning = false;
+        
+        if ([navigationController.topViewController respondsToSelector:@selector(transitionCoordinator)]) {
+            id <UIViewControllerTransitionCoordinator> transitionCoordinator = navigationController.topViewController.transitionCoordinator;
+            [transitionCoordinator notifyWhenInteractionEndsUsingBlock:^(id <UIViewControllerTransitionCoordinatorContext> context) {
+                if ([context isCancelled]) {
+                    @synchronized (self.stack) {
+                        self.transitioning = false;
+                    }
                 }
-            }
-        }];
+            }];
+        }
     }
 }
 


### PR DESCRIPTION
This commit fixes iOS 5/6 incompatibility (introduced in b1fc75e) by adding a simple `-respondsToSelector:` check.
